### PR TITLE
Hide C++11 features from header files

### DIFF
--- a/include/fastjet/ClusterSequence.hh
+++ b/include/fastjet/ClusterSequence.hh
@@ -40,7 +40,6 @@
 #include<string>
 #include<set>
 #include<cmath> // needed to get double std::abs(double)
-#include <atomic>
 #include "fastjet/Error.hh"
 #include "fastjet/JetDefinition.hh"
 #include "fastjet/SharedPtr.hh"
@@ -557,7 +556,7 @@ public:
   /// by default. This requirement reflects the spirit of
   /// clause 2c of the GNU Public License (v2), under which
   /// FastJet and its plugins are distributed.
-  static void set_fastjet_banner_stream(std::ostream * ostr) {_fastjet_banner_ostr = ostr;}
+  static void set_fastjet_banner_stream(std::ostream * ostr);
   //  [this line must be left as is to hide the doxygen comment]
   /// \endcond
 
@@ -565,13 +564,18 @@ public:
   /// (cout by default). This function is used by plugins to determine
   /// where to direct their banners. Plugins should properly handle
   /// the case where the pointer is null.
-  static std::ostream * fastjet_banner_stream() {return _fastjet_banner_ostr;}
+  static std::ostream * fastjet_banner_stream();
 
 private:
   /// \cond internal_doc
 
+  // CMS change: _fastjet_banner_ostr is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   /// contains the actual stream to use for banners 
-  static std::atomic<std::ostream*> _fastjet_banner_ostr;
+  //static std::ostream* _fastjet_banner_ostr;
 
   /// \endcond
 
@@ -731,13 +735,23 @@ protected:
   			      const DynamicNearestNeighbours * DNN);
 
 
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   /// will be set by default to be true for the first run
-  static std::atomic<bool> _first_time;
+  //static bool _first_time;
 
+  // CMS change: _n_exclusive_warnings is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   /// record the number of warnings provided about the exclusive
   /// algorithm -- so that we don't print it out more than a few
   /// times.
-  static std::atomic<int> _n_exclusive_warnings;
+  //static int _n_exclusive_warnings;
 
   /// the limited warning member for notification of user that 
   /// their requested strategy has been overridden (usually because

--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -31,7 +31,6 @@
 
 #include<iostream>
 #include<string>
-#include<atomic>
 #include "fastjet/internal/base.hh"
 
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
@@ -57,25 +56,36 @@ public:
   /// the error message
   std::string message() const {return _message;}
 
+
+  // CMS change: the following three static functions 
+  //  are no longer defined in the header.
+  // Change not endorsed by fastjet collaboration 
+
   /// controls whether the error message (and the backtrace, if its printing is enabled) 
   /// is printed out or not
-  static void set_print_errors(bool print_errors) {_print_errors = print_errors;}
+  static void set_print_errors(bool print_errors);// {_print_errors = print_errors;}
 
   /// controls whether the backtrace is printed out with the error message or not.
   /// The default is "false".
-  static void set_print_backtrace(bool enabled) {_print_backtrace = enabled;}
+  static void set_print_backtrace(bool enabled); // {_print_backtrace = enabled;}
 
   /// sets the default output stream for all errors; by default
   /// cerr; if it's null then error output is suppressed.
-  static void set_default_stream(std::ostream * ostr) {
-    _default_ostr = ostr;
-  }
+  static void set_default_stream(std::ostream * ostr);// {
+  //  _default_ostr = ostr;
+  //}
 
 private:
   std::string _message;                ///< error message
-  static std::atomic<bool> _print_errors;           ///< do we print anything?
-  static std::atomic<bool> _print_backtrace;        ///< do we print the backtrace?
-  static std::atomic<std::ostream*> _default_ostr; ///< the output stream (cerr if not set)
+
+  // CMS change: the following are no longer class statics
+  //  moved to file static since they were changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _print_errors;           ///< do we print anything?
+  //static bool _print_backtrace;        ///< do we print the backtrace?
+  //static std::ostream* _default_ostr; ///< the output stream (cerr if not set)
 };
 
 

--- a/include/fastjet/GhostedAreaSpec.hh
+++ b/include/fastjet/GhostedAreaSpec.hh
@@ -172,19 +172,21 @@ public:
   inline int nphi() const {return _nphi;}
   inline int nrap() const {return _nrap;}
 
+  //CMS change: can no longer be inlined
+  // Change not endorsed by fastjet collaboration
   /// get all relevant information about the status of the 
   /// random number generator, so that it can be reset subsequently
   /// with set_random_status.
-  inline void get_random_status(std::vector<int> & __iseed) const {
-    _random_generator.get_status(__iseed);}
+  void get_random_status(std::vector<int> & __iseed) const;
 
+  //CMS change: can no longer be inlined
+  // Change not endorsed by fastjet collaboration
   /// set the status of the random number generator, as obtained
   /// previously with get_random_status. Note that the random
   /// generator is a static member of the class, i.e. common to all
   /// instances of the class --- so if you modify the random for this
   /// instance, you modify it for all instances.
-  inline void set_random_status(const std::vector<int> & __iseed) {
-    _random_generator.set_status(__iseed);}
+  void set_random_status(const std::vector<int> & __iseed);
   
   inline void checkpoint_random() {get_random_status(_random_checkpoint);}
   inline void restore_checkpoint_random() {set_random_status(_random_checkpoint);}
@@ -199,9 +201,10 @@ public:
   /// very deprecated public access to a random number 
   /// from the internal generator
   inline double random_at_own_risk() const {return _our_rand();}
+  //CMS change: can no longer be inlined
+  // Change not endorsed by fastjet collaboration
   /// very deprecated public access to the generator itself
-  inline BasicRandom<double> & generator_at_own_risk() const {
-    return _random_generator;}
+  BasicRandom<double> & generator_at_own_risk() const;
 
 private:
   
@@ -223,10 +226,16 @@ private:
 
 
   std::vector<int> _random_checkpoint;
-  static thread_local BasicRandom<double> _random_generator;
+  //CMS change: _random_generator no longer class static since
+  // thread safety requires it to be thread_local but the header
+  // needs to be parsed by non C++11 compilers 
+  // Change not endorsed by fastjet collaboration
+  //static BasicRandom<double> _random_generator;
   //mutable BasicRandom<double> _random_generator;
 
-  inline double _our_rand() const {return _random_generator();}
+  //CMS change: no longer inlined
+  // Change not endorsed by fastjet collaboration
+  double _our_rand() const;
   
 };
 

--- a/include/fastjet/LimitedWarning.hh
+++ b/include/fastjet/LimitedWarning.hh
@@ -34,7 +34,9 @@
 #include <iostream>
 #include <string>
 #include <list>
+#if __cplusplus >= 201103L
 #include <atomic>
+#endif
 
 FASTJET_BEGIN_NAMESPACE
 
@@ -59,17 +61,21 @@ public:
   /// outputs a warning to the specified stream
   void warn(const std::string & warning, std::ostream * ostr);
 
+  // CMS change: the following two static functions 
+  //  are no longer defined in the header.
+  // Change not endorsed by fastjet collaboration 
+
   /// sets the default output stream for all warnings (by default
   /// cerr; passing a null pointer prevents warnings from being output)
-  static void set_default_stream(std::ostream * ostr) {
-    _default_ostr = ostr;
-  }
+  static void set_default_stream(std::ostream * ostr);// {
+  //  _default_ostr = ostr;
+  //}
 
   /// sets the default maximum number of warnings of a given kind
   /// before warning messages are silenced.
-  static void set_default_max_warn(int max_warn) {
-    _max_warn_default = max_warn;
-  }
+  static void set_default_max_warn(int max_warn); //{
+  //  _max_warn_default = max_warn;
+  //}
 
   /// returns a summary of all the warnings that came through the
   /// LimiteWarning class
@@ -77,20 +83,37 @@ public:
 
   //std::atomic can not be stored directly in a std::list
   struct atomic_counter {
+#if __cplusplus >= 201103L
     std::atomic<unsigned int> _count;
+#else
+    unsigned int _count;
+#endif
     atomic_counter(): _count(0) {}
     atomic_counter(unsigned int iValue): _count(iValue) {}
+#if __cplusplus >= 201103L
     atomic_counter( const atomic_counter& iOther): _count(iOther._count.load()) {}
+#else
+    atomic_counter( const atomic_counter& iOther): _count(iOther) {}
+#endif
 
   };
 private:
+  typedef std::pair<std::string, atomic_counter > Summary;
   const int _max_warn;
+  // CMS change: change to std::atomic for thread safety
+  // Change not endorsed by fastjet collaboration 
+#if __cplusplus >= 201103L
   std::atomic<int> _n_warn_so_far;
   static std::atomic<int> _max_warn_default;
   static std::atomic<std::ostream*> _default_ostr;
-  typedef std::pair<std::string, atomic_counter > Summary;
-  static std::list< Summary > _global_warnings_summary;
   std::atomic<Summary*> _this_warning_summary;
+#else
+  int _n_warn_so_far;
+  int _max_warn_default;
+  std::ostream* _default_ostr;
+  Summary* _this_warning_summary;
+#endif
+  static std::list< Summary > _global_warnings_summary;
   
 };
 

--- a/plugins/ATLASCone/ATLASConePlugin.cc
+++ b/plugins/ATLASCone/ATLASConePlugin.cc
@@ -38,12 +38,20 @@
 // other stuff
 #include <vector>
 #include <sstream>
-
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
 using namespace std;
 
-std::atomic<bool> ATLASConePlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
 
 string ATLASConePlugin::description () const {
   ostringstream desc;
@@ -155,8 +163,13 @@ void ATLASConePlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void ATLASConePlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/ATLASCone/fastjet/ATLASConePlugin.hh
+++ b/plugins/ATLASCone/fastjet/ATLASConePlugin.hh
@@ -89,7 +89,13 @@ private:
   double _seedPt;   ///< the pt seed threshold used in stable-cone search
   double _f;        ///< the overlap thresholod used in the split-merge
 
-  static std::atomic<bool> _first_time;
+
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/CDFCones/CDFMidPointPlugin.cc
+++ b/plugins/CDFCones/CDFMidPointPlugin.cc
@@ -30,6 +30,9 @@
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/Error.hh"
 #include <sstream>
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 
 // CDF stuff
 #include "MidPointAlgorithm.hh"
@@ -41,7 +44,13 @@ FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 using namespace std;
 using namespace cdf;
 
-std::atomic<bool> CDFMidPointPlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
 
 string CDFMidPointPlugin::description () const {
   ostringstream desc;
@@ -154,8 +163,13 @@ void CDFMidPointPlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void CDFMidPointPlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/CDFCones/fastjet/CDFJetCluPlugin.hh
+++ b/plugins/CDFCones/fastjet/CDFJetCluPlugin.hh
@@ -32,7 +32,6 @@
 #include "fastjet/JetDefinition.hh"
 #include "fastjet/PseudoJet.hh"
 #include <map>
-#include <atomic>
 
 // questionable whether this should be in fastjet namespace or not...
 
@@ -99,7 +98,12 @@ private:
   /// as ensure that the jet energy is unique
   void _insert_unique (PseudoJet & jet, std::map<double,int> & jetmap) const;
 
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/CDFCones/fastjet/CDFMidPointPlugin.hh
+++ b/plugins/CDFCones/fastjet/CDFMidPointPlugin.hh
@@ -29,7 +29,6 @@
 #ifndef __CDFMIDPOINTPLUGIN_HH__
 #define __CDFMIDPOINTPLUGIN_HH__
 
-#include <atomic>
 #include "fastjet/JetDefinition.hh"
 
 // questionable whether this should be in fastjet namespace or not...
@@ -170,7 +169,12 @@ private:
   double _overlap_threshold ;
   SplitMergeScale _sm_scale ;
 
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/CMSIterativeCone/CMSIterativeConePlugin.cc
+++ b/plugins/CMSIterativeCone/CMSIterativeConePlugin.cc
@@ -63,6 +63,9 @@
 #include <vector>
 #include <list>
 #include <sstream>
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 #include "SortByEt.h"
 
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
@@ -89,7 +92,14 @@ T deltaR2 (T eta1, T phi1, T eta2, T phi2) {
 }
 
 //------------------------------------------------------
-std::atomic<bool> CMSIterativeConePlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
+
 
 string CMSIterativeConePlugin::description () const {
   ostringstream desc;
@@ -222,8 +232,13 @@ void CMSIterativeConePlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void CMSIterativeConePlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time ) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/CMSIterativeCone/fastjet/CMSIterativeConePlugin.hh
+++ b/plugins/CMSIterativeCone/fastjet/CMSIterativeConePlugin.hh
@@ -79,7 +79,12 @@ private:
   double theConeRadius;     ///< cone radius
   double theSeedThreshold;  ///< seed threshold
 
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/D0RunICone/D0RunIBaseConePlugin.cc
+++ b/plugins/D0RunICone/D0RunIBaseConePlugin.cc
@@ -29,6 +29,9 @@
 // D0 stuff
 // apparently this has to go first to avoid a problem with gcc-4.0.1 builds on Macs
 #include <list>
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 #include "ConeClusterAlgo.hpp"
 #include "HepEntityIpre96.h"
 #include "HepEntityI.h"
@@ -149,7 +152,13 @@ void D0RunIBaseConePlugin::run_clustering_worker(ClusterSequence & clust_seq) co
 //                                         //
 /////////////////////////////////////////////
 
-std::atomic<bool> D0RunIpre96ConePlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
 
 string D0RunIpre96ConePlugin::description () const {
   ostringstream desc;
@@ -171,8 +180,13 @@ void D0RunIpre96ConePlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void D0RunIpre96ConePlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  
@@ -197,7 +211,13 @@ void D0RunIpre96ConePlugin::_print_banner(ostream *ostr) const{
 //                                         //
 /////////////////////////////////////////////
 
-std::atomic<bool> D0RunIConePlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> D0RunIConePlugin_first_time{true};
+#else
+static bool D0RunIConePlugin_first_time{true};
+#endif
 
 string D0RunIConePlugin::description () const {
   ostringstream desc;
@@ -219,8 +239,13 @@ void D0RunIConePlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void D0RunIConePlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
-  if (! _first_time.compare_exchange_strong(expected,false)) return;
+  if (! D0RunIConePlugin_first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if( ! D0RunIConePlugin_first_time ) return;
+  D0RunIConePlugin_first_time = true;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/D0RunICone/fastjet/D0RunIConePlugin.hh
+++ b/plugins/D0RunICone/fastjet/D0RunIConePlugin.hh
@@ -29,7 +29,6 @@
 //----------------------------------------------------------------------
 //ENDHEADER
 
-#include <atomic>
 #include "fastjet/D0RunIBaseConePlugin.hh"
 
 // questionable whether this should be in fastjet namespace or not...
@@ -85,7 +84,12 @@ public:
   virtual void run_clustering(ClusterSequence &) const;
 
 private:
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/D0RunICone/fastjet/D0RunIpre96ConePlugin.hh
+++ b/plugins/D0RunICone/fastjet/D0RunIpre96ConePlugin.hh
@@ -28,7 +28,6 @@
 //  along with FastJet. If not, see <http://www.gnu.org/licenses/>.
 //----------------------------------------------------------------------
 //ENDHEADER
-#include <atomic>
 #include "fastjet/D0RunIBaseConePlugin.hh"
 
 // questionable whether this should be in fastjet namespace or not...
@@ -85,7 +84,12 @@ public:
   virtual void run_clustering(ClusterSequence &) const;
 
 private:
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/D0RunIICone/D0RunIIConePlugin.cc
+++ b/plugins/D0RunIICone/D0RunIIConePlugin.cc
@@ -30,6 +30,9 @@
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/Error.hh"
 #include <sstream>
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 
 // D0 stuff
 #include <list>
@@ -53,7 +56,13 @@ const double D0RunIIConePlugin::_DEFAULT_pT_min_second_protojet   = 0.   ;
 const int    D0RunIIConePlugin::_DEFAULT_merge_max                = 10000; 
 const double D0RunIIConePlugin::_DEFAULT_pT_min_nomerge           = 0.   ;
 
-std::atomic<bool> D0RunIIConePlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
 
 string D0RunIIConePlugin::description () const {
   ostringstream desc;
@@ -143,8 +152,13 @@ void D0RunIIConePlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void D0RunIIConePlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/D0RunIICone/fastjet/D0RunIIConePlugin.hh
+++ b/plugins/D0RunIICone/fastjet/D0RunIIConePlugin.hh
@@ -29,7 +29,6 @@
 //----------------------------------------------------------------------
 //ENDHEADER
 
-#include <atomic>
 #include "fastjet/JetDefinition.hh"
 
 // questionable whether this should be in fastjet namespace or not...
@@ -155,7 +154,12 @@ private:
   const static int    _DEFAULT_merge_max               ;// = 10000; 
   const static double _DEFAULT_pT_min_nomerge          ;// = 0.   ;
 
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/plugins/SISCone/SISConePlugin.cc
+++ b/plugins/SISCone/SISConePlugin.cc
@@ -25,9 +25,17 @@ template<> PseudoJet::PseudoJet(const siscone::Cmomentum & four_vector) {
 /////////////////////////////////////////////
 // static members declaration              //
 /////////////////////////////////////////////
-thread_local std::auto_ptr<SISConePlugin>           SISConePlugin::stored_plugin;
-thread_local std::auto_ptr<std::vector<PseudoJet> > SISConePlugin::stored_particles;
-thread_local std::auto_ptr<Csiscone>                SISConePlugin::stored_siscone;
+//CMS change: separate stores for each thread.
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local std::auto_ptr<SISConePlugin>           stored_plugin;
+static thread_local std::auto_ptr<std::vector<PseudoJet> > stored_particles;
+static thread_local std::auto_ptr<Csiscone>                stored_siscone;
+#else
+static std::auto_ptr<SISConePlugin>           stored_plugin;
+static std::auto_ptr<std::vector<PseudoJet> > stored_particles;
+static std::auto_ptr<Csiscone>                stored_siscone;
+#endif
 
 
 /////////////////////////////////////////////

--- a/plugins/SISCone/SISConeSphericalPlugin.cc
+++ b/plugins/SISCone/SISConeSphericalPlugin.cc
@@ -24,10 +24,17 @@ template<> PseudoJet::PseudoJet(const siscone_spherical::CSphmomentum & four_vec
 /////////////////////////////////////////////
 // static members declaration              //
 /////////////////////////////////////////////
-thread_local std::auto_ptr<SISConeSphericalPlugin>  SISConeSphericalPlugin::stored_plugin;
-thread_local std::auto_ptr<std::vector<PseudoJet> > SISConeSphericalPlugin::stored_particles;
-thread_local std::auto_ptr<CSphsiscone>             SISConeSphericalPlugin::stored_siscone;
-
+//CMS change: separate stores for each thread.
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local std::auto_ptr<SISConeSphericalPlugin>  stored_plugin;
+static thread_local std::auto_ptr<std::vector<PseudoJet> > stored_particles;
+static thread_local std::auto_ptr<CSphsiscone>             stored_siscone;
+#else
+static std::auto_ptr<SISConeSphericalPlugin>  stored_plugin;
+static std::auto_ptr<std::vector<PseudoJet> > stored_particles;
+static std::auto_ptr<CSphsiscone>             stored_siscone;
+#endif
 
 /////////////////////////////////////////////
 // now comes the implementation itself     //

--- a/plugins/SISCone/fastjet/SISConePlugin.hh
+++ b/plugins/SISCone/fastjet/SISConePlugin.hh
@@ -183,11 +183,17 @@ private:
 
   bool _use_pt_weighted_splitting;
 
+
+  // CMS change: stored_* are no longer class statics.
+  //  moved to file statics since they were changed to thread_local
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   // part needed for the cache 
   // variables for caching the results and the input
-  static thread_local std::auto_ptr<SISConePlugin          > stored_plugin;
-  static thread_local std::auto_ptr<std::vector<PseudoJet> > stored_particles;
-  static thread_local std::auto_ptr<siscone::Csiscone      > stored_siscone;
+  //static std::auto_ptr<SISConePlugin          > stored_plugin;
+  //static std::auto_ptr<std::vector<PseudoJet> > stored_particles;
+  //static std::auto_ptr<siscone::Csiscone      > stored_siscone;
 };
 
 

--- a/plugins/SISCone/fastjet/SISConeSphericalPlugin.hh
+++ b/plugins/SISCone/fastjet/SISConeSphericalPlugin.hh
@@ -159,11 +159,17 @@ private:
   SplitMergeScale _split_merge_scale;
   bool _use_E_weighted_splitting;
 
+  // CMS change: stored_* are no longer class statics.
+  //  moved to file statics since they were changed to thread_local
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   // part needed for the cache 
   // variables for caching the results and the input
-  static thread_local std::auto_ptr<SISConeSphericalPlugin        > stored_plugin;
-  static thread_local std::auto_ptr<std::vector<PseudoJet>        > stored_particles;
-  static thread_local std::auto_ptr<siscone_spherical::CSphsiscone> stored_siscone;
+  //static std::auto_ptr<SISConeSphericalPlugin        > stored_plugin;
+  //static std::auto_ptr<std::vector<PseudoJet>        > stored_particles;
+  //static std::auto_ptr<siscone_spherical::CSphsiscone> stored_siscone;
+
 };
 
 //======================================================================

--- a/plugins/SISCone/siscone/siscone/geom_2d.cpp
+++ b/plugins/SISCone/siscone/siscone/geom_2d.cpp
@@ -44,8 +44,15 @@ using namespace std;
 
 // static member default init
 //----------------------------
-thread_local double Ceta_phi_range::eta_min = -100.0;
-thread_local double Ceta_phi_range::eta_max = 100.0;
+//CMS change: separate eta range per thread
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local double g_eta_min = -100.0;
+static thread_local double g_eta_max = 100.0;
+#else
+static double g_eta_min = -100.0;
+static double g_eta_max = 100.0;
+#endif
 
 // default ctor
 //--------------
@@ -63,8 +70,8 @@ Ceta_phi_range::Ceta_phi_range(){
 Ceta_phi_range::Ceta_phi_range(double c_eta, double c_phi, double R){
   // determination of the eta range
   //-------------------------------
-  double xmin = max(c_eta-R,eta_min+0.0001);
-  double xmax = min(c_eta+R,eta_max-0.0001);
+  double xmin = max(c_eta-R,g_eta_min+0.0001);
+  double xmax = min(c_eta+R,g_eta_max-0.0001);
 
   unsigned int cell_min = get_eta_cell(xmin);
   unsigned int cell_max = get_eta_cell(xmax);
@@ -118,6 +125,19 @@ int Ceta_phi_range::add_particle(const double eta, const double phi){
   return 0;
 }
 
+// CMS change: function no longer defined in header
+// Change not endorsed by fastjet collaboration 
+inline unsigned int Ceta_phi_range::get_eta_cell(double eta){
+  return (unsigned int) (1 << ((int) (32*((eta-g_eta_min)/(g_eta_max-g_eta_min)))));
+}
+
+double& Ceta_phi_range::eta_min() {
+  return g_eta_min;
+}
+
+double& Ceta_phi_range::eta_max() {
+  return g_eta_max;
+}
 
 // test overlap
 //  - r1  first range

--- a/plugins/SISCone/siscone/siscone/geom_2d.h
+++ b/plugins/SISCone/siscone/siscone/geom_2d.h
@@ -146,14 +146,19 @@ public:
   unsigned int phi_range;     
 
   // extremal value for eta
-  static thread_local double eta_min;  ///< minimal value for eta
-  static thread_local double eta_max;  ///< maximal value for eta
+  // CMS change: eta_min, eta_max are no longer class statics
+  //  moved to file static since they were changed to thread_local
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static double eta_min;  ///< minimal value for eta
+  //static double eta_max;  ///< maximal value for eta
+  static double& eta_min();
+  static double& eta_max();
 
 private:
   /// return the cell index corrsponding to an eta value
-  inline unsigned int get_eta_cell(double eta){
-    return (unsigned int) (1 << ((int) (32*((eta-eta_min)/(eta_max-eta_min)))));
-  }
+  inline unsigned int get_eta_cell(double eta);
 
   /// return the cell index corrsponding to a phi value
   inline unsigned int get_phi_cell(double phi){

--- a/plugins/SISCone/siscone/siscone/ranlux.cpp
+++ b/plugins/SISCone/siscone/siscone/ranlux.cpp
@@ -55,8 +55,13 @@ typedef struct {
 
 // internal generator state
 //--------------------------
+//CMS change: separate ranlux for each thread.
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
 static thread_local ranlux_state_t local_ranlux_state;
-
+#else
+static ranlux_state_t local_ranlux_state;
+#endif
 
 // incrementation of the generator state
 //---------------------------------------

--- a/plugins/SISCone/siscone/siscone/siscone.cpp
+++ b/plugins/SISCone/siscone/siscone/siscone.cpp
@@ -65,7 +65,13 @@ Csiscone::~Csiscone(){
   rerun_allowed = false;
 }
 
-thread_local bool Csiscone::init_done=false;
+//CMS change: separate generators for each thread.
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local bool init_done=false;
+#else
+static bool init_done=false;
+#endif
 std::ostream* Csiscone::_banner_ostr = 0;
 
 /*

--- a/plugins/SISCone/siscone/siscone/siscone.h
+++ b/plugins/SISCone/siscone/siscone/siscone.h
@@ -95,8 +95,13 @@ class Csiscone : public Cstable_cones, public Csplit_merge{
   /// list of protocones found pass-by-pass
   std::vector<std::vector<Cmomentum> > protocones_list;
 
+  // CMS change: init_done is no longer a class static
+  //  moved to file static since it was changed to thread_local
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   // random number initialisation
-  static thread_local bool init_done;      ///< check random generator initialisation
+  //static bool init_done;      ///< check random generator initialisation
 
 #ifdef DEBUG_STABLE_CONES
   int nb_hash_cones_total, nb_hash_occupied_total;

--- a/plugins/SISCone/siscone/siscone/siscone_error.cpp
+++ b/plugins/SISCone/siscone/siscone/siscone_error.cpp
@@ -25,9 +25,26 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "siscone_error.h"
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 
 namespace siscone{
 
-std::atomic<bool> Csiscone_error::m_print_errors{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+std::atomic<bool> m_print_errors{true};
+#else
+bool m_print_errors = true;
+#endif
+
+void Csiscone_error::setm_print_errors(bool print_errors) {
+  m_print_errors = print_errors;
+};
+
+void Csiscone_error::printMessage(const std::string& message_in) {
+  if (m_print_errors) std::cerr << "siscone::Csiscone_error: "<< message_in << std::endl;
+}
 
 }

--- a/plugins/SISCone/siscone/siscone/siscone_error.h
+++ b/plugins/SISCone/siscone/siscone/siscone_error.h
@@ -30,7 +30,6 @@
 
 #include<iostream>
 #include<string>
-#include<atomic>
 
 namespace siscone{
 
@@ -45,20 +44,33 @@ public:
   ///  \param message_in   the error message to be printed
   Csiscone_error(const std::string & message_in) {
     m_message = message_in; 
-    if (m_print_errors) std::cerr << "siscone::Csiscone_error: "<< message_in << std::endl;
+  // CMS change: hide implementation of printing the error
+  // Change not endorsed by fastjet collaboration 
+    printMessage(message_in);
   };
 
   /// access to the error message
   std::string message() const {return m_message;};
 
+  // CMS change: move implementation to source file
+  // Change not endorsed by fastjet collaboration 
   /// switch on/off the error message printing
   ///  \param print_errors   errors will be printed when true
-  static void setm_print_errors(bool print_errors) {
-    m_print_errors = print_errors;};
+  static void setm_print_errors(bool print_errors);// {
+  //  m_print_errors = print_errors;};
 
 private:
+  // CMS change: hide implementation of printing the error
+  // Change not endorsed by fastjet collaboration 
+  void printMessage(const std::string& message_in);
+
   std::string m_message;       ///< the error message
-  static std::atomic<bool> m_print_errors;  ///< do we print error messages?
+  // CMS change: m_print_errors is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool m_print_errors;  ///< do we print error messages?
 };
 
 }

--- a/plugins/SISCone/siscone/siscone/spherical/siscone.cpp
+++ b/plugins/SISCone/siscone/siscone/spherical/siscone.cpp
@@ -67,7 +67,14 @@ CSphsiscone::~CSphsiscone(){
   rerun_allowed = false;
 }
 
-thread_local bool CSphsiscone::init_done=false;
+//CMS change: separate generators for each thread.
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local bool init_done=false;
+#else
+static bool init_done=false;
+#endif
+
 std::ostream* CSphsiscone::_banner_ostr=&cout;
 
 /*

--- a/plugins/SISCone/siscone/siscone/spherical/siscone.h
+++ b/plugins/SISCone/siscone/siscone/spherical/siscone.h
@@ -95,8 +95,13 @@ class CSphsiscone : public CSphstable_cones, public CSphsplit_merge{
   /// list of protocones found pass-by-pass
   std::vector<std::vector<CSphmomentum> > protocones_list;
 
+  // CMS change: init_done is no longer a class static
+  //  moved to file static since it was changed to thread_local
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
   // random number initialisation
-  static thread_local bool init_done;      ///< check random generator initialisation
+  //static bool init_done;      ///< check random generator initialisation
 
 #ifdef DEBUG_STABLE_CONES
   int nb_hash_cones_total, nb_hash_occupied_total;

--- a/plugins/SISCone/siscone/siscone/split_merge.cpp
+++ b/plugins/SISCone/siscone/siscone/split_merge.cpp
@@ -344,8 +344,8 @@ int Csplit_merge::init_pleft(){
   n_pass = 0;
 
   Ceta_phi_range epr;
-  epr.eta_min = eta_min-0.01;
-  epr.eta_max = eta_max+0.01;
+  epr.eta_min() = eta_min-0.01;
+  epr.eta_max() = eta_max+0.01;
 
   merge_collinear_and_remove_soft();
 

--- a/plugins/TrackJet/TrackJetPlugin.cc
+++ b/plugins/TrackJet/TrackJetPlugin.cc
@@ -66,6 +66,9 @@
 #include <cmath>
 #include <vector>
 #include <sstream>
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
@@ -91,7 +94,13 @@ public:
 // implementation of the TrackJet plugin
 //------------------------------------------------------------------
 
-std::atomic<bool> TrackJetPlugin::_first_time{true};
+//CMS change: use std::atomic for thread safety
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+#else
+static bool _first_time = true;
+#endif
 
 string TrackJetPlugin::description () const {
   ostringstream desc;
@@ -190,8 +199,13 @@ void TrackJetPlugin::run_clustering(ClusterSequence & clust_seq) const {
 
 // print a banner for reference to the 3rd-party code
 void TrackJetPlugin::_print_banner(ostream *ostr) const{
+#if __cplusplus >= 201103L
   bool expected = true;
   if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   if (!ostr) return;  

--- a/plugins/TrackJet/fastjet/TrackJetPlugin.hh
+++ b/plugins/TrackJet/fastjet/TrackJetPlugin.hh
@@ -29,7 +29,6 @@
 #ifndef __TRACKJETPLUGIN_HH__
 #define __TRACKJETPLUGIN_HH__
 
-#include <atomic>
 #include "fastjet/JetDefinition.hh"
 
 // questionable whether this should be in fastjet namespace or not...
@@ -86,7 +85,12 @@ private:
   JetDefinition::DefaultRecombiner _jet_recombiner;
   JetDefinition::DefaultRecombiner _track_recombiner;
 
-  static std::atomic<bool> _first_time;
+  // CMS change: _first_time is no longer a class static
+  //  moved to file static since it was changed to std::atomic
+  //  and we still need to allow this header to be parsed by
+  //  non C++11 compilers.
+  // Change not endorsed by fastjet collaboration 
+  //static bool _first_time;
 
   /// print a banner for reference to the 3rd-party code
   void _print_banner(std::ostream *ostr) const;

--- a/src/ClusterSequence.cc
+++ b/src/ClusterSequence.cc
@@ -40,6 +40,12 @@
 #include<string>
 #include<set>
 
+//CMS change: 
+// Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
+
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
 //----------------------------------------------------------------------
@@ -127,6 +133,8 @@ FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 using namespace std;
 
 
+//CMS change: use std::atomic for thread safety.
+//   Change not endorsed by fastjet collaboration
 // The following variable can be modified from within user code
 // so as to redirect banners to an ostream other than cout.
 //
@@ -136,7 +144,11 @@ using namespace std;
 // by default. This requirement reflects the spirit of
 // clause 2c of the GNU Public License (v2), under which
 // FastJet and its plugins are distributed.
-std::atomic<std::ostream*> ClusterSequence::_fastjet_banner_ostr{nullptr};
+#if __cplusplus >= 201103L
+static std::atomic<std::ostream*> _fastjet_banner_ostr{nullptr};
+#else
+static std::ostream* _fastjet_banner_ostr = 0;
+#endif
 
 
 // destructor that guarantees proper bookkeeping for the CS Structure
@@ -357,8 +369,15 @@ void ClusterSequence::_initialise_and_run_no_decant () {
 
 
 // these needs to be defined outside the class definition.
-std::atomic<bool> ClusterSequence::_first_time{true};
-std::atomic<int> ClusterSequence::_n_exclusive_warnings{0};
+//CMS change: use std::atomic for thread safety.
+//   Change not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static std::atomic<bool> _first_time{true};
+static std::atomic<int> _n_exclusive_warnings{0};
+#else
+static bool _first_time =true;
+static int _n_exclusive_warnings =0;
+#endif
 
 
 //----------------------------------------------------------------------
@@ -367,13 +386,22 @@ string fastjet_version_string() {
   return "FastJet version "+string(fastjet_version);
 }
 
+//CMS change: function definition no longer in header
+//   Change not endorsed by fastjet collaboration
+void ClusterSequence::set_fastjet_banner_stream(std::ostream * ostr) {_fastjet_banner_ostr = ostr;}
+std::ostream * ClusterSequence::fastjet_banner_stream() {return _fastjet_banner_ostr;}
 
 //----------------------------------------------------------------------
 // prints a banner on the first call
 void ClusterSequence::print_banner() {
 
+#if __cplusplus >= 201103L
   bool expected = true;
-  if (!_first_time.compare_exchange_strong(expected,false)) {return;}
+  if (! _first_time.compare_exchange_strong(expected,false)) return;
+#else
+  if (! _first_time) return;
+  _first_time = false;
+#endif
 
   // make sure the user has not set the banner stream to NULL
   ostream * ostr = _fastjet_banner_ostr;

--- a/src/GhostedAreaSpec.cc
+++ b/src/GhostedAreaSpec.cc
@@ -35,7 +35,13 @@ using namespace std;
 
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
-thread_local BasicRandom<double> GhostedAreaSpec::_random_generator;
+//CMS change: separate generators for each thread.
+// Not endorsed by fastjet collaboration
+#if __cplusplus >= 201103L
+static thread_local BasicRandom<double> _random_generator;
+#else
+static BasicRandom<double> _random_generator;
+#endif
 
 /// explicit constructor
 GhostedAreaSpec::GhostedAreaSpec(
@@ -171,6 +177,23 @@ string GhostedAreaSpec::description() const {
        << ", n repetitions of ghost distributions =  " << repeat();
   return ostr.str();
 }
+
+ void GhostedAreaSpec::get_random_status(std::vector<int> & __iseed) const {
+  _random_generator.get_status(__iseed);
+}
+
+ void GhostedAreaSpec::set_random_status(const std::vector<int> & __iseed) {
+  _random_generator.set_status(__iseed);
+}
+
+BasicRandom<double> & GhostedAreaSpec::generator_at_own_risk() const {
+  return _random_generator;
+}
+
+double GhostedAreaSpec::_our_rand() const {
+  return _random_generator();
+}
+
 
 FASTJET_END_NAMESPACE
 


### PR DESCRIPTION
We want to compile third party libraries using these fastjet
headers using compiler options that may not include C++11 support
but still link to our libraries built with C++11. This requires
all C++11 constructs to either be removed from the headers or
hidden (in the case where their pre C++11 equivalents are binary
compatible).

This change also attempts to make it possible to compile all of
fastjet with a non C++11 compiler.

In addition, we have attempted to fulfill the request by the
fastjet maintainers to comment the CMS changes and explicitly state
that the changes are not sanctioned by the fastjet maintainers.
