### PR TITLE
fastjet bug try again - 

### DIFF
--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -103,6 +103,25 @@ private:
   //static std::ostream* _default_ostr; ///< the output stream (cerr if not set)
 };
 
+//----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+/// @ingroup error_handling
+/// \class InternalError
+/// class corresponding to critical internal errors
+/// 
+/// This is an error class (derived from Error) meant for serious,
+/// critical, internal errors that we still want to be catchable by an
+/// end-user [e.g. a serious issue in clustering where the end-user
+/// can catch it and retry with a different strategy]
+///
+/// Please directly contact the FastJet authors if you see such an
+/// error.
+class InternalError : public Error{
+public:
+  /// ctor with error message:
+  /// just add a bit of info to the message and pass it to the base class
+  InternalError(const std::string & message_in) : Error(std::string("*** CRITICAL INTERNAL FASTJET ERROR *** CONTACT THE AUTHORS *** ") + message_in){ }
+};
+
 
 FASTJET_END_NAMESPACE
 

--- a/include/fastjet/internal/LazyTiling9Alt.hh
+++ b/include/fastjet/internal/LazyTiling9Alt.hh
@@ -37,6 +37,40 @@
 
 FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
+//----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+/// Rounding errors in the Lazy strategies may cause the following
+/// problem: when browsing tiles in the vicinity of the particles
+/// being clustered in order to decide which of these tiles may
+/// contain particles that need to be updated (because theit NN is one
+/// of the particles that are currently clustered), we discard tiles
+/// that are deemed "too far from the cell" by the "max_NN_dist"
+/// criterion. Because of rounding error, this condition can sometimes
+/// miss cases where an update is needed.
+///
+/// An example of this happens if a particle '1' is, say, at the lower
+/// edge of the rapidity of a given tile, with a particle '2' in the
+/// tile directly on its left at the same rapidity. Assume also that
+/// max_NN_dist in 2's tile corresponds to the distance between 2 and
+/// teh tile of 1. If 2 is 1's NN then in case 2 gets clustered, 1's
+/// NN needs to be updated. However, rounding errors in the
+/// calculation of the distance between 1 and 2 may result is
+/// something slightly larger than the max_NN_dist in 2's tile.
+///
+/// This situation corresponds to the bug reported by Jochen Olt on
+/// February 12 2015 [see issue-tracker/2015-02-infinite-loop],
+/// causing an infinite loop.
+///
+/// To prevent this, the simplest solution is, when looking at tiles
+/// to browse for updateds, to add a margin of security close to the
+/// edges of the cell, i.e. instead of updating only tiles for which
+/// distance<=max_NN_dist, we will update tiles for which
+/// distance<=max_NN_dist+tile_edge_security_margin.
+///
+/// Note that this does not need to be done when computing nearest
+/// neighbours [rounding errors are tolerated there] but it is
+/// critical when tracking points that have to be updated.
+const double tile_edge_security_margin=1.0e-7;
+
 /// structure analogous to BriefJet, but with the extra information
 /// needed for dealing with tiles
 class TiledJet {

--- a/src/ClusterSequence.cc
+++ b/src/ClusterSequence.cc
@@ -1500,10 +1500,26 @@ void ClusterSequence::_add_step_to_history (
   int local_step = _history.size()-1;
   assert(local_step == step_number);
 
+  //----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+  // sanity check: make sure the particles have not already been recombined
+  //
+  // Note that good practice would make this an assert (since this is
+  // a serious internal issue). However, we decided to throw an
+  // InternalError so that the end user can decide to catch it and
+  // retry the clustering with a different strategy.
+ 
   assert(parent1 >= 0);
+  if (_history[parent1].child != Invalid){
+    throw InternalError("trying to recomine an object that has previsously been recombined");
+  }
   _history[parent1].child = local_step;
-  if (parent2 >= 0) {_history[parent2].child = local_step;}
-
+  if (parent2 >= 0) {
+    if (_history[parent2].child != Invalid){
+      throw InternalError("trying to recomine an object that has previsously been recombined");
+    }
+    _history[parent2].child = local_step;
+  }
+  
   // get cross-referencing right from PseudoJets
   if (jetp_index != Invalid) {
     assert(jetp_index >= 0);

--- a/src/LazyTiling25.cc
+++ b/src/LazyTiling25.cc
@@ -368,7 +368,10 @@ inline void LazyTiling25::_add_untagged_neighbours_to_tile_union_using_max_info(
   
   for (Tile25 ** near_tile = tile.begin_tiles; near_tile != tile.end_tiles; near_tile++){
     if ((*near_tile)->tagged) continue;
-    double dist = _distance_to_tile(jet, *near_tile);
+    //----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+    // here we are not allowed to miss a tile due to some rounding
+    // error. We therefore allow for a margin of security
+    double dist = _distance_to_tile(jet, *near_tile) - tile_edge_security_margin;    
     // (*_safe_cout) << "      max info looked at tile " << *near_tile - &_tiles[0] 
     // 	 << ", dist = " << dist << " " << (*near_tile)->max_NN_dist
     // 	 << endl;

--- a/src/LazyTiling9.cc
+++ b/src/LazyTiling9.cc
@@ -355,7 +355,10 @@ inline void LazyTiling9::_add_untagged_neighbours_to_tile_union_using_max_info(
   
   for (Tile2 ** near_tile = tile.begin_tiles; near_tile != tile.end_tiles; near_tile++){
     if ((*near_tile)->tagged) continue;
-    double dist = _distance_to_tile(jet, *near_tile);
+    //----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+    // here we are not allowed to miss a tile due to some rounding
+    // error. We therefore allow for a margin of security
+    double dist = _distance_to_tile(jet, *near_tile) - tile_edge_security_margin;    
     // (*_safe_cout) << "      max info looked at tile " << *near_tile - &_tiles[0] 
     // 	 << ", dist = " << dist << " " << (*near_tile)->max_NN_dist
     // 	 << endl;

--- a/src/LazyTiling9Alt.cc
+++ b/src/LazyTiling9Alt.cc
@@ -331,7 +331,10 @@ inline void LazyTiling9Alt::_add_untagged_neighbours_to_tile_union_using_max_inf
   
   for (Tile::TileFnPair * near_tile = tile.begin_tiles; near_tile != tile.end_tiles; near_tile++){
     if ((near_tile->first)->tagged) continue;
-    double dist = (tile.*(near_tile->second))(jet);
+    //----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+    // here we are not allowed to miss a tile due to some rounding
+    // error. We therefore allow for a margin of security
+    double dist = (tile.*(near_tile->second))(jet) - tile_edge_security_margin;
     // (*_safe_cout) << "      max info looked at tile " << *near_tile - &_tiles[0] 
     // 	 << ", dist = " << dist << " " << (*near_tile)->max_NN_dist
     // 	 << endl;

--- a/src/LazyTiling9SeparateGhosts.cc
+++ b/src/LazyTiling9SeparateGhosts.cc
@@ -310,7 +310,10 @@ inline void LazyTiling9SeparateGhosts::_add_untagged_neighbours_to_tile_union_us
   
   for (Tile3 ** near_tile = tile.begin_tiles; near_tile != tile.end_tiles; near_tile++){
     if ((*near_tile)->tagged) continue;
-    double dist = _distance_to_tile(jet, *near_tile);
+    //----- Copy of fix from fastjet authors fastjet-3.1.2-devel-20150224-rev3823.tar
+    // here we are not allowed to miss a tile due to some rounding
+    // error. We therefore allow for a margin of security
+    double dist = _distance_to_tile(jet, *near_tile) - tile_edge_security_margin;    
     // (*_safe_cout) << "      max info looked at tile " << *near_tile - &_tiles[0] 
     // 	 << ", dist = " << dist << " " << (*near_tile)->max_NN_dist
     // 	 << endl;


### PR DESCRIPTION
Redoing https://github.com/cms-externals/fastjet/pull/12 but with correct base fork.

Summary:
A bug in fastjet which resulted in infinite loops was reported by Jochen Ott (@jottCern) and a fix was provided by the fastjet authors (fastjet-3.1.2-devel-20150224-rev3823). I've mirrored the changes here.
