### PR TITLE
Remove duplicated InternalError class

### DIFF
--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -120,7 +120,7 @@ public:
   /// ctor with error message:
   /// just add a bit of info to the message and pass it to the base class
   InternalError(const std::string & message_in) : Error(std::string("*** CRITICAL INTERNAL FASTJET ERROR *** CONTACT THE AUTHORS *** ") + message_in){ }
-}
+};
 
 FASTJET_END_NAMESPACE
 

--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -122,25 +122,6 @@ public:
   InternalError(const std::string & message_in) : Error(std::string("*** CRITICAL INTERNAL FASTJET ERROR *** CONTACT THE AUTHORS *** ") + message_in){ }
 }
 
-
-/// @ingroup error_handling
-/// \class InternalError
-/// class corresponding to critical internal errors
-/// 
-/// This is an error class (derived from Error) meant for serious,
-/// critical, internal errors that we still want to be catchable by an
-/// end-user [e.g. a serious issue in clustering where the end-user
-/// can catch it and retry with a different strategy]
-///
-/// Please directly contact the FastJet authors if you see such an
-/// error.
-class InternalError : public Error{
-public:
-  /// ctor with error message:
-  /// just add a bit of info to the message and pass it to the base class
-  InternalError(const std::string & message_in) : Error(std::string("*** CRITICAL INTERNAL FASTJET ERROR *** CONTACT THE AUTHORS *** ") + message_in){ }
-};
-
 FASTJET_END_NAMESPACE
 
 #endif // __FASTJET_ERROR_HH__

--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -120,7 +120,7 @@ public:
   /// ctor with error message:
   /// just add a bit of info to the message and pass it to the base class
   InternalError(const std::string & message_in) : Error(std::string("*** CRITICAL INTERNAL FASTJET ERROR *** CONTACT THE AUTHORS *** ") + message_in){ }
-};
+}
 
 
 /// @ingroup error_handling


### PR DESCRIPTION
I don't know how this happened, but somehow github seemed to have trouble with these few lines. Trying again. 