### PR TITLE
bring Error::description definition

### DIFF
--- a/include/fastjet/Error.hh
+++ b/include/fastjet/Error.hh
@@ -62,7 +62,7 @@ public:
   /// the error message
   std::string message() const {return _message;}
 
-
+  std::string description() const {return message();}
 
   // CMS change: the following three static functions 
   //  are no longer defined in the header.


### PR DESCRIPTION
Bring back the definition of description, see https://github.com/cms-sw/cmsdist/pull/3865